### PR TITLE
Add support for que v1

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -14,6 +14,8 @@ jobs:
       postgres:
         image: postgres:${{ matrix.postgres_version }}
         ports: ["5432:5432"]
+        env:
+          POSTGRES_HOST_AUTH_METHOD: trust
         options: >-
           --health-cmd pg_isready
           --health-interval 10s

--- a/.ruby-gemset
+++ b/.ruby-gemset
@@ -1,0 +1,1 @@
+que-locks

--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,6 @@ source "https://rubygems.org"
 
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
-gem "que", "1.0.0.beta3", github: "que-rb/que", ref: "53106609b24d7e8bc231ae3883f69dca8c989d9d"
-
 # Specify your gem's dependencies in que-locks.gemspec
 gemspec
 
@@ -14,6 +12,7 @@ group :development do
   gem "database_cleaner"
 
   gem "minitest"
+  gem "mocha"
 
   gem "byebug"
   gem "rufo"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,9 @@
-GIT
-  remote: https://github.com/que-rb/que
-  revision: 53106609b24d7e8bc231ae3883f69dca8c989d9d
-  ref: 53106609b24d7e8bc231ae3883f69dca8c989d9d
-  specs:
-    que (1.0.0.beta3)
-
 PATH
   remote: .
   specs:
     que-locks (0.2.0)
       neatjson
-      que (~> 1.0.0.beta3)
+      que (~> 1.0)
       xxhash
 
 GEM
@@ -40,11 +33,13 @@ GEM
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
     minitest (5.14.0)
+    mocha (1.14.0)
     neatjson (0.9)
     parallel (1.19.1)
     parser (2.7.0.2)
       ast (~> 2.4.0)
     pg (1.2.2)
+    que (1.4.1)
     rainbow (3.0.0)
     rake (10.5.0)
     rubocop (0.79.0)
@@ -75,8 +70,8 @@ DEPENDENCIES
   byebug
   database_cleaner
   minitest
+  mocha
   pg
-  que (= 1.0.0.beta3)!
   que-locks!
   rake (~> 10.0)
   rubocop
@@ -84,4 +79,4 @@ DEPENDENCIES
   rufo
 
 BUNDLED WITH
-   2.1.4
+   2.3.18

--- a/README.md
+++ b/README.md
@@ -26,8 +26,6 @@ Or install it yourself as:
 $ gem install que-locks
 ```
 
-**Note**: `que-locks` is built for Que 1.0, which is at this time not the default version of que you'll get if you don't specify a prerelease que version like `1.0.0.beta3` in your application's Gemfile.
-
 ## Usage
 
 After requiring the gem, set the `exclusive_execution_lock` property on your job class:
@@ -46,7 +44,7 @@ That's it!
 
 ## Configuration (Important!)
 
-Right now, `que-locks` does __not__ support Que running with a `--worker-count` greater than 1! This is because the locking strategy is not compatible with the way Que uses it's connection pool. This is a big limitation we hope to remove, but please note that you must run Que with one worker per process when using `que-locks`. 
+Right now, `que-locks` does __not__ support Que running with a `--worker-count` greater than 1! This is because the locking strategy is not compatible with the way Que uses its connection pool. This is a big limitation we hope to remove, but please note that you must run Que with one worker per process when using `que-locks`.
 
 ### Checking lock status
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,12 @@
-version: "3.6"
-
-volumes:
-  postgres-data:
-    driver: local
+version: '3.2'
 
 services:
   postgres:
-    image: postgres:11.2
-    volumes:
-      - postgres-data:/var/lib/postgresql/data:delegated
+    image: postgres:12
     ports:
       - 5432:5432
     restart: on-failure
     environment:
       POSTGRES_USER: que_locks
       POSTGRES_DB: que_locks_test
+      POSTGRES_HOST_AUTH_METHOD: trust # don't require password

--- a/lib/que/locks/job_extensions.rb
+++ b/lib/que/locks/job_extensions.rb
@@ -2,25 +2,34 @@ module Que::Locks
   module JobExtensions
     attr_accessor :exclusive_execution_lock
 
-    def lock_available?(*args, queue: nil, priority: nil, run_at: nil, job_class: nil, tags: nil, **arg_opts) # rubocop:disable Lint/UnusedMethodArgument
-      args << arg_opts if arg_opts.any?
+    def lock_available?(*args, queue: nil, priority: nil, run_at: nil, job_class: nil, tags: nil, job_options: {}, **kwargs) # rubocop:disable Lint/UnusedMethodArgument
+      args << kwargs if kwargs.any?
       return true unless self.exclusive_execution_lock
       return false if Que::Locks::ExecutionLock.already_enqueued_job_wanting_lock?(self, args)
       return Que::Locks::ExecutionLock.can_aquire?(self, args)
     end
 
-    def enqueue(*args, queue: nil, priority: nil, run_at: nil, job_class: nil, tags: nil, **arg_opts)
+    def enqueue(*args, queue: nil, priority: nil, run_at: nil, job_class: nil, tags: nil, job_options: {}, **kwargs)
+      forwardable_kwargs = kwargs.clone
+      forwardable_kwargs[:job_options] = {
+        queue: queue,
+        priority: priority,
+        run_at: run_at,
+        job_class: job_class,
+        tags: tags,
+      }.merge(job_options)
+
       if self.exclusive_execution_lock
         args_list = args.clone
-        args_list << arg_opts if arg_opts.any?
+        args_list << kwargs if kwargs.any?
 
         if Que::Locks::ExecutionLock.already_enqueued_job_wanting_lock?(self, args_list)
           Que.log(level: :info, event: :skipped_enqueue_due_to_preemptive_lock_check, args: args_list)
         else
-          super
+          super(*args, **forwardable_kwargs)
         end
       else
-        super
+        super(*args, **forwardable_kwargs)
       end
     end
   end

--- a/que-locks.gemspec
+++ b/que-locks.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
 
   spec.add_dependency "neatjson"
-  spec.add_dependency "que", "~> 1.0.0.beta3"
+  spec.add_dependency "que", "~> 1.0"
   spec.add_dependency "xxhash"
 end

--- a/test/test_execution_lock.rb
+++ b/test/test_execution_lock.rb
@@ -69,7 +69,11 @@ class TestExecutionLock < Minitest::Test
   end
 
   def test_release_unaquired_lock
-    assert Que::Locks::ExecutionLock.release!(123)
+    _, stderr = capture_subprocess_io do
+      assert Que::Locks::ExecutionLock.release!(123)
+    end
+
+    assert_includes stderr, "you don't own a lock"
   end
 
   def test_checking_lock_after_aquisition_doesnt_release

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,5 @@
 require "minitest/autorun"
+require "mocha/minitest"
 require "que"
 require "que/locks"
 require "byebug"
@@ -11,8 +12,8 @@ ActiveRecord::Base.establish_connection(ENV.fetch("DATABASE_URL", "postgres://qu
 Que.connection = ActiveRecord
 Que::Migrations.migrate!(version: Que::Migrations::CURRENT_VERSION)
 
-Que.logger = Logger.new(STDOUT)
-Que.internal_logger = Logger.new(STDOUT)
+Que.logger = Logger.new(STDOUT, level: Logger::WARN)
+Que.internal_logger = Logger.new(STDOUT, level: Logger::WARN)
 DatabaseCleaner.strategy = :truncation
 
 class Minitest::Test
@@ -50,7 +51,7 @@ class Minitest::Test
   end
 
   def run_jobs
-    job_buffer = Que::JobBuffer.new(maximum_size: 20, minimum_size: 0, priorities: [10, 30, 50, nil])
+    job_buffer = Que::JobBuffer.new(maximum_size: 20, priorities: [10, 30, 50, nil])
     result_queue = Que::ResultQueue.new
 
     jobs = ActiveRecord::Base.connection.execute("SELECT * FROM que_jobs;").to_a.map do |job|


### PR DESCRIPTION
Currently, Que Locks has a very specific version dependency on a Que v1 prerelease, and cannot be used with Que 1.0 or later. This PR resolves #4 by loosening up the dependency in the gemspec, and updating APIs to be compatible with v1.