### PR TITLE
Adding que 2/ruby 3 support

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         postgres_version: [9, 10, 11, 12]
-        ruby_version: ['2.5', '2.6']
+        ruby_version: ['2.5', '2.6', '3.2']
 
     services:
       postgres:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         postgres_version: [9, 10, 11, 12]
-        ruby_version: ['2.5', '2.6', '3.2']
+        ruby_version: ['3.2']
 
     services:
       postgres:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         postgres_version: [9, 10, 11, 12]
-        ruby_version: ['3.2']
+        ruby_version: ['2.5', '2.6', '3.2']
 
     services:
       postgres:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     que-locks (0.4.1)
       neatjson (~> 0.9)
-      que (~> 1.0)
+      que (~> 2.2)
       xxhash (~> 0.4)
 
 GEM
@@ -68,7 +68,7 @@ GEM
     parser (3.1.2.0)
       ast (~> 2.4.1)
     pg (1.4.2)
-    que (1.4.1)
+    que (2.2.1)
     racc (1.6.0)
     rack (2.2.4)
     rack-test (2.0.2)
@@ -85,7 +85,7 @@ GEM
       rake (>= 0.13)
       thor (~> 1.0)
     rainbow (3.1.1)
-    rake (10.5.0)
+    rake (13.0.6)
     regexp_parser (2.5.0)
     rexml (3.2.5)
     rubocop (1.32.0)
@@ -126,7 +126,7 @@ DEPENDENCIES
   pg
   que-locks!
   railties
-  rake (~> 10.0)
+  rake (~> 13.0)
   rubocop
   rubocop-performance
   rufo

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     que-locks (0.4.1)
       neatjson (~> 0.9)
-      que (~> 2.2)
+      que (>= 1.0, < 2.3)
       xxhash (~> 0.4)
 
 GEM

--- a/lib/que/locks/active_job_extensions.rb
+++ b/lib/que/locks/active_job_extensions.rb
@@ -28,11 +28,11 @@ module Que::Locks
       end
 
       que_job = if require_job_options_kwarg?
-        ExclusiveJobWrapper.enqueue job.serialize, job_options: job_options
-      else
-        ExclusiveJobWrapper.enqueue job.serialize, **job_options
-      end
-      
+          ExclusiveJobWrapper.enqueue job.serialize, job_options: job_options
+        else
+          ExclusiveJobWrapper.enqueue job.serialize, **job_options
+        end
+
       if que_job && job.respond_to?(:provider_job_id=)
         job.provider_job_id = que_job.attrs["job_id"]
       end

--- a/lib/que/locks/active_job_extensions.rb
+++ b/lib/que/locks/active_job_extensions.rb
@@ -23,13 +23,27 @@ module Que::Locks
       # https://github.com/rails/rails/pull/19498)
       if job.respond_to?(:queue_name) && ::ActiveJob.version.segments.first > 4
         job_options[:queue] = job.queue_name
+      else
+        job_options[:queue] = "default"
       end
 
-      que_job = ExclusiveJobWrapper.enqueue job.serialize, job_options: job_options
+      que_job = if require_job_options_kwarg?
+        ExclusiveJobWrapper.enqueue job.serialize, job_options: job_options
+      else
+        ExclusiveJobWrapper.enqueue job.serialize, **job_options
+      end
+      
       if que_job && job.respond_to?(:provider_job_id=)
         job.provider_job_id = que_job.attrs["job_id"]
       end
       que_job
+    end
+
+    private
+
+    def require_job_options_kwarg?
+      @require_job_options_kwarg ||=
+        self.method(:enqueue).parameters.any? { |ptype, pname| ptype == :key && pname == :job_options }
     end
   end
 end

--- a/que-locks.gemspec
+++ b/que-locks.gemspec
@@ -21,10 +21,10 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", '~> 2.0'
+  spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 13.0"
 
-  spec.add_dependency "neatjson", '~> 0.9'
-  spec.add_dependency "que", ['>= 1.0', '< 2.3']
-  spec.add_dependency "xxhash", '~> 0.4'
+  spec.add_dependency "neatjson", "~> 0.9"
+  spec.add_dependency "que", [">= 1.0", "< 2.3"]
+  spec.add_dependency "xxhash", "~> 0.4"
 end

--- a/que-locks.gemspec
+++ b/que-locks.gemspec
@@ -22,9 +22,9 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", '~> 2.0'
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", "~> 13.0"
 
   spec.add_dependency "neatjson", '~> 0.9'
-  spec.add_dependency "que", "~> 1.0"
+  spec.add_dependency "que", "~> 2.2"
   spec.add_dependency "xxhash", '~> 0.4'
 end

--- a/que-locks.gemspec
+++ b/que-locks.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 13.0"
 
   spec.add_dependency "neatjson", '~> 0.9'
-  spec.add_dependency "que", "~> 2.2"
+  spec.add_dependency "que", ['>= 1.0', '< 2.3']
   spec.add_dependency "xxhash", '~> 0.4'
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -39,9 +39,11 @@ class Minitest::Test
     Que.run_synchronously = old
   end
 
-  ruby2_keywords def sleep_until(*args, &block)
+  def sleep_until(*args, &block)
     sleep_until?(*args, &block) || raise("sleep_until timeout reached")
   end
+
+  ruby2_keywords(:sleep_until) if respond_to?(:ruby2_keywords, true)
 
   def sleep_until?(timeout: SLEEP_UNTIL_TIMEOUT)
     deadline = Time.now + timeout

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -65,7 +65,7 @@ class Minitest::Test
     jobs = ActiveRecord::Base.connection.execute("SELECT * FROM que_jobs;").to_a.map do |job|
       job.symbolize_keys!
       job[:args] = JSON.parse(job[:args])
-      job[:kwargs] = JSON.parse(job[:kwargs])
+      job[:kwargs] = JSON.parse(job[:kwargs]) if job[:kwargs]
       job
     end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -39,7 +39,7 @@ class Minitest::Test
     Que.run_synchronously = old
   end
 
-  def sleep_until(*args, &block)
+  ruby2_keywords def sleep_until(*args, &block)
     sleep_until?(*args, &block) || raise("sleep_until timeout reached")
   end
 
@@ -65,6 +65,7 @@ class Minitest::Test
     jobs = ActiveRecord::Base.connection.execute("SELECT * FROM que_jobs;").to_a.map do |job|
       job.symbolize_keys!
       job[:args] = JSON.parse(job[:args])
+      job[:kwargs] = JSON.parse(job[:kwargs])
       job
     end
 

--- a/test/test_que_locks.rb
+++ b/test/test_que_locks.rb
@@ -283,10 +283,10 @@ class TestQueLocks < Minitest::Test
   end
 
   def test_can_enqueue_locked_active_job
-    key = '_aj_symbol_keys'
+    key = "_aj_symbol_keys"
 
-    if Gem::Version.new(Que::VERSION) >= Gem::Version.new('2.0')
-      key = '_aj_ruby2_keywords'
+    if Gem::Version.new(Que::VERSION) >= Gem::Version.new("2.0")
+      key = "_aj_ruby2_keywords"
     end
 
     assert_args = lambda do |klass, args|

--- a/test/test_que_locks.rb
+++ b/test/test_que_locks.rb
@@ -283,11 +283,17 @@ class TestQueLocks < Minitest::Test
   end
 
   def test_can_enqueue_locked_active_job
+    key = '_aj_symbol_keys'
+
+    if Gem::Version.new(Que::VERSION) >= Gem::Version.new('2.0')
+      key = '_aj_ruby2_keywords'
+    end
+
     assert_args = lambda do |klass, args|
       assert_equal Que::Locks::ActiveJobExtensions::ExclusiveJobWrapper, klass
       assert_equal 1, args.length
       assert_equal "TestActiveJob", args.first["job_class"]
-      assert_equal [1, { "unrelated" => { "_aj_serialized" => "ActiveJob::Serializers::SymbolSerializer", "value" => "qux" }, "_aj_symbol_keys" => ["unrelated"] }], args.first["arguments"]
+      assert_equal [1, { "unrelated" => { "_aj_serialized" => "ActiveJob::Serializers::SymbolSerializer", "value" => "qux" }, key => ["unrelated"] }], args.first["arguments"]
     end
 
     mock_lock = mock("lock")


### PR DESCRIPTION
Implemented que 2 and ruby 3 support.
Ruby 3 support is handled the same way as que gem (using ruby2_keywords gem)
Please let me know if there is anything I can do to get this up to get this pull request up standard.